### PR TITLE
Fix logical coords being used for cursor position

### DIFF
--- a/src/systems.rs
+++ b/src/systems.rs
@@ -290,7 +290,7 @@ where
 }
 
 fn cursor_pos(window: &Window) -> Option<Vec2> {
-    window.cursor_position()
+    window.physical_cursor_position()
 }
 
 /// Something that has a size on screen.


### PR DESCRIPTION
Fixes an issue where focusing with the mouse does not work correctly when `scale_factor` != 1.0

This is related to:

https://bevyengine.org/learn/migration-guides/0-14-to-0-15/#only-use-physical-coords-internally-in-bevy-ui

But switching the coordinate system for the cursor position seems like a straightforward way to fix it.