### PR TITLE
Upgrade to Bevy 0.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           components: clippy,rustfmt
 
       - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default = ["bevy_reflect"]
 bevy_reflect = []
 
 [dependencies]
-bevy = { version = "0.16", default-features = false, features = [
+bevy = { version = "0.17.0-rc.1", default-features = false, features = [
     "bevy_asset",
     "bevy_ui",
     "bevy_render",
@@ -28,4 +28,4 @@ non-empty-vec = { version = "0.2.2", default-features = false }
 
 [dev-dependencies]
 fastrand = "2.0.1"
-bevy = { version = "0.16", default-features = true }
+bevy = { version = "0.17.0-rc.1", default-features = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default = ["bevy_reflect"]
 bevy_reflect = []
 
 [dependencies]
-bevy = { version = "0.17.0-rc.1", default-features = false, features = [
+bevy = { version = "0.17.0", default-features = false, features = [
     "bevy_asset",
     "bevy_ui",
     "bevy_render",
@@ -28,4 +28,4 @@ non-empty-vec = { version = "0.2.2", default-features = false }
 
 [dev-dependencies]
 fastrand = "2.0.1"
-bevy = { version = "0.17.0-rc.1", default-features = true }
+bevy = { version = "0.17.0", default-features = true }

--- a/examples/infinite_upgrades.rs
+++ b/examples/infinite_upgrades.rs
@@ -523,7 +523,7 @@ fn spawn_button(commands: &mut EntityCommands, color: Color, at: Vec2, text: Str
                     font_size: FONT_SIZE,
                     ..default()
                 },
-                TextLayout::new_with_justify(JustifyText::Center),
+                TextLayout::new_with_justify(Justify::Center),
                 item_position(Vec2::ZERO),
             ));
         });
@@ -570,7 +570,7 @@ fn spawn_weapon_upgrade_menu(
                     font_size: FONT_SIZE,
                     ..default()
                 },
-                TextLayout::new_with_justify(JustifyText::Center),
+                TextLayout::new_with_justify(Justify::Center),
                 item_position(Vec2::Y * (MENU_HEIGHT / 2.0 - MENU_PADDING - FONT_SIZE / 2.0)),
             ));
 

--- a/examples/infinite_upgrades.rs
+++ b/examples/infinite_upgrades.rs
@@ -184,7 +184,7 @@ pub fn mouse_pointer_system(
     mouse: Res<ButtonInput<MouseButton>>,
     focusables: Query<(&GlobalTransform, &Sprite, Entity), With<Focusable>>,
     focused: Query<Entity, With<Focused>>,
-    mut nav_cmds: EventWriter<NavRequest>,
+    mut nav_cmds: MessageWriter<NavRequest>,
 ) {
     // If the camera is currently moving, skip mouse pointing
     if camera_moving.iter().next().is_some() {
@@ -429,13 +429,13 @@ fn animate_system(mut animated: Query<(&Animate, &mut Transform)>, time: Res<Tim
 
 /// Move camera to the menu that is currently focused if the focus changed menu.
 fn handle_menu_change(
-    mut nav_events: EventReader<NavEvent>,
+    mut nav_events: MessageReader<NavMessage>,
     mut cam: Query<&mut Animate, With<Camera2d>>,
     menu_position: Query<&GlobalTransform, With<Menu>>,
     menu_query: Query<&ParentMenu>,
 ) {
     for event in nav_events.read() {
-        if let NavEvent::FocusChanged { to, from } = event {
+        if let NavMessage::FocusChanged { to, from } = event {
             let menu_query = (menu_query.get(*from.first()), menu_query.get(*to.first()));
             if let (Ok(from), Ok(to)) = menu_query {
                 if from.0 != to.0 {
@@ -461,8 +461,8 @@ fn handle_menu_change(
 /// Handle generating new menus when an upgrade is selected.
 fn upgrade_weapon(
     mut commands: Commands,
-    mut events: EventReader<NavEvent>,
-    mut requests: EventWriter<NavRequest>,
+    mut events: MessageReader<NavMessage>,
+    mut requests: MessageWriter<NavRequest>,
     (mut menus, time): (ResMut<MenuMap>, Res<Time>),
     mut cam: Query<&mut Animate, With<Camera2d>>,
     query: Query<(&ParentMenu, &WeaponUpgrade, &SpawnDirection, Entity)>,
@@ -482,7 +482,7 @@ fn upgrade_weapon(
         if menus.is_free(at) {
             // Exercise to the reader: write an alternate system that does not use
             // `Menu.weapon`, but instead reads the `WeaponUpgrade` component of all
-            // focusable in the `from` field of `NavEvent::NoChanges` to generate
+            // focusable in the `from` field of `NavMessage::NoChanges` to generate
             // the current weapon upgrade.
             let menu = spawn_weapon_upgrade_menu(&mut commands, at, &weapon, Some(entity));
             menus.grid.insert(at, menu);

--- a/examples/locking.rs
+++ b/examples/locking.rs
@@ -27,13 +27,13 @@ fn main() {
         .run();
 }
 
-fn print_nav_events(mut events: EventReader<NavEvent>) {
+fn print_nav_events(mut events: MessageReader<NavMessage>) {
     for event in events.read() {
         info!("{:?}", event);
     }
 }
 
-fn extra_lock_key(mut requests: EventWriter<NavRequest>, input: Res<ButtonInput<KeyCode>>) {
+fn extra_lock_key(mut requests: MessageWriter<NavRequest>, input: Res<ButtonInput<KeyCode>>) {
     if input.just_pressed(KeyCode::KeyL) {
         requests.write(NavRequest::Lock);
     }

--- a/examples/marking.rs
+++ b/examples/marking.rs
@@ -34,7 +34,7 @@ column_type!(enum RightColMenu, 6);
 /// 1. How to register multiple marking types
 /// 2. How to add menu markers that automatically add components to focusables
 ///    within the menu
-/// 3. How to use the marker components to tell menus involved in `NavEvent`
+/// 3. How to use the marker components to tell menus involved in `NavMessage`
 ///    events.
 ///
 /// It constructs 9 menus of 3 buttons, you can navigate between them with the

--- a/examples/menu_navigation.rs
+++ b/examples/menu_navigation.rs
@@ -2,7 +2,7 @@ use bevy::{color::palettes::css::*, prelude::*};
 
 use bevy_alt_ui_navigation_lite::{
     prelude::{
-        DefaultNavigationPlugins, FocusState, Focusable, MenuBuilder, MenuSetting, NavEvent,
+        DefaultNavigationPlugins, FocusState, Focusable, MenuBuilder, MenuSetting, NavMessage,
         NavRequest, NavRequestSystem,
     },
     systems::InputMapping,
@@ -89,17 +89,17 @@ fn button_system(
 }
 
 fn handle_nav_events(
-    mut events: EventReader<NavEvent>,
-    mut requests: EventWriter<NavRequest>,
+    mut events: MessageReader<NavMessage>,
+    mut requests: MessageWriter<NavRequest>,
     game: Res<Gameui>,
 ) {
     use NavRequest::Action;
     for event in events.read() {
-        if let NavEvent::FocusChanged { from, to } = &event {
+        if let NavMessage::FocusChanged { from, to } = &event {
             info!("----------\nfrom: {:?}\n  to: {:?}", from, to);
         }
         match event {
-            NavEvent::NoChanges {
+            NavMessage::NoChanges {
                 from,
                 request: Action,
             } if game.from.contains(from.first()) => {

--- a/examples/menu_navigation.rs
+++ b/examples/menu_navigation.rs
@@ -50,7 +50,7 @@ impl Gameui {
     pub fn new() -> Self {
         Self {
             from: Vec::new(),
-            to: Entity::from_raw(1),
+            to: Entity::from_raw_u32(1).unwrap(),
         }
     }
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -35,7 +35,7 @@ fn button_system(
     }
 }
 
-fn print_nav_events(mut events: EventReader<NavEvent>) {
+fn print_nav_events(mut events: MessageReader<NavMessage>) {
     for event in events.read() {
         info!("{:?}", event);
     }

--- a/examples/too_many_focusables.rs
+++ b/examples/too_many_focusables.rs
@@ -55,7 +55,7 @@ impl Default for MyDirection {
 
 fn non_stop_move(
     input: Res<ButtonInput<KeyCode>>,
-    mut requests: EventWriter<NavRequest>,
+    mut requests: MessageWriter<NavRequest>,
     mut enabled: Local<bool>,
     time: Res<Time>,
     mut last_direction: Local<MyDirection>,

--- a/src/events.rs
+++ b/src/events.rs
@@ -2,8 +2,8 @@
 //!
 //! The navigation system works through bevy's `Events` system.
 //! It is a system with one input and two outputs:
-//! * Input `EventWriter<NavRequest>`, tells the navigation system what to do.
-//!   Your app should have a system that writes to a `EventWriter<NavRequest>`
+//! * Input `MessageWriter<NavRequest>`, tells the navigation system what to do.
+//!   Your app should have a system that writes to a `MessageWriter<NavRequest>`
 //!   based on inputs or internal game state.
 //!   Bevy provides default systems in `bevy_ui`.
 //!   But you can add your own requests on top of the ones the default systems send.
@@ -12,26 +12,25 @@
 //!   The navigation system updates the focusables component
 //!   according to the focus state of the navigation system.
 //!   See `examples/cursor_navigation` directory for usage clues.
-//! * Output `EventReader<NavEvent>`,
+//! * Output `MessageReader<NavMessage>`,
 //!   contains specific information about what the navigation system is doing.
 //!
 //! [`Focusable`]: crate::resolve::Focusable
 use bevy::{
     ecs::{
         entity::Entity,
-        event::EventReader,
+        message::{Message, MessageReader},
         query::{QueryData, QueryFilter, ReadOnlyQueryData},
         system::Query,
     },
     math::Vec2,
-    prelude::Event,
 };
 use non_empty_vec::NonEmpty;
 
 use crate::resolve::LockReason;
 
 /// Requests to send to the navigation system to update focus.
-#[derive(Debug, PartialEq, Clone, Copy, Event)]
+#[derive(Debug, PartialEq, Clone, Copy, Message)]
 pub enum NavRequest {
     /// Move in in provided direction according to the plugin's [navigation strategy].
     ///
@@ -70,13 +69,13 @@ pub enum NavRequest {
 
     /// Locks the navigation system.
     ///
-    /// A [`NavEvent::Locked`] will be emitted as a response if the
+    /// A [`NavMessage::Locked`] will be emitted as a response if the
     /// navigation system was not already locked.
     Lock,
 
     /// Unlocks the navigation system.
     ///
-    /// A [`NavEvent::Unlocked`] will be emitted as a response if the
+    /// A [`NavMessage::Unlocked`] will be emitted as a response if the
     /// navigation system was indeed locked.
     Unlock,
 }
@@ -121,11 +120,11 @@ impl Direction {
 
 /// Events emitted by the navigation system.
 ///
-/// Useful if you want to react to [`NavEvent::NoChanges`] event, for example
+/// Useful if you want to react to [`NavMessage::NoChanges`] event, for example
 /// when a "start game" button is focused and the [`NavRequest::Action`] is
 /// pressed.
-#[derive(Debug, Clone, Event)]
-pub enum NavEvent {
+#[derive(Debug, Clone, Message)]
+pub enum NavMessage {
     /// Tells the app which element is the first one to be focused.
     ///
     /// This will be sent whenever the number of focused elements go from 0 to 1.
@@ -186,54 +185,54 @@ pub enum NavEvent {
     /// [lock]: crate::resolve::NavLock
     Unlocked(LockReason),
 }
-impl NavEvent {
+impl NavMessage {
     /// Create a `FocusChanged` with a single `to`
     ///
-    /// Usually the `NavEvent::FocusChanged.to` field has a unique value.
-    pub(crate) fn focus_changed(to: Entity, from: NonEmpty<Entity>) -> NavEvent {
-        NavEvent::FocusChanged {
+    /// Usually the `NavMessage::FocusChanged.to` field has a unique value.
+    pub(crate) fn focus_changed(to: Entity, from: NonEmpty<Entity>) -> NavMessage {
+        NavMessage::FocusChanged {
             from,
             to: NonEmpty::new(to),
         }
     }
 
-    /// Whether this event is a [`NavEvent::NoChanges`]
+    /// Whether this event is a [`NavMessage::NoChanges`]
     /// triggered by a [`NavRequest::Action`]
     /// if `entity` is the currently focused element.
     pub fn is_activated(&self, entity: Entity) -> bool {
-        matches!(self, NavEvent::NoChanges { from,  request: NavRequest::Action } if *from.first() == entity)
+        matches!(self, NavMessage::NoChanges { from,  request: NavRequest::Action } if *from.first() == entity)
     }
 }
 
-/// Extend [`EventReader<NavEvent>`] with methods
-/// to simplify working with [`NavEvent`]s.
+/// Extend [`MessageReader<NavMessage>`] with methods
+/// to simplify working with [`NavMessage`]s.
 ///
-/// See the [`NavEventReader`] documentation for details.
+/// See the [`NavMessageReader`] documentation for details.
 ///
-/// [`EventReader<NavEvent>`]: EventReader
-pub trait NavEventReaderExt<'w, 's> {
-    /// Create a [`NavEventReader`] from this event reader.
-    fn nav_iter(&mut self) -> NavEventReader<'w, 's, '_>;
+/// [`MessageReader<NavMessage>`]: MessageReader
+pub trait NavMessageReaderExt<'w, 's> {
+    /// Create a [`NavMessageReader`] from this event reader.
+    fn nav_iter(&mut self) -> NavMessageReader<'w, 's, '_>;
 }
-impl<'w, 's> NavEventReaderExt<'w, 's> for EventReader<'w, 's, NavEvent> {
-    fn nav_iter(&mut self) -> NavEventReader<'w, 's, '_> {
-        NavEventReader { event_reader: self }
+impl<'w, 's> NavMessageReaderExt<'w, 's> for MessageReader<'w, 's, NavMessage> {
+    fn nav_iter(&mut self) -> NavMessageReader<'w, 's, '_> {
+        NavMessageReader { event_reader: self }
     }
 }
 
-/// A wrapper for `EventReader<NavEvent>` to simplify dealing with [`NavEvent`]s.
-pub struct NavEventReader<'w, 's, 'a> {
-    event_reader: &'a mut EventReader<'w, 's, NavEvent>,
+/// A wrapper for `MessageReader<NavMessage>` to simplify dealing with [`NavMessage`]s.
+pub struct NavMessageReader<'w, 's, 'a> {
+    event_reader: &'a mut MessageReader<'w, 's, NavMessage>,
 }
 
-impl NavEventReader<'_, '_, '_> {
-    /// Iterate over [`NavEvent::NoChanges`] focused entity
+impl NavMessageReader<'_, '_, '_> {
+    /// Iterate over [`NavMessage::NoChanges`] focused entity
     /// triggered by `request` type requests.
     pub fn with_request(&mut self, request: NavRequest) -> impl Iterator<Item = Entity> + '_ {
         self.event_reader
             .read()
             .filter_map(move |nav_event| match nav_event {
-                NavEvent::NoChanges {
+                NavMessage::NoChanges {
                     from,
                     request: event_request,
                 } if *event_request == request => Some(*from.first()),
@@ -250,10 +249,10 @@ impl NavEventReader<'_, '_, '_> {
         self.with_request(NavRequest::Action)
     }
 
-    /// Iterate over [`NavEvent`]s, associating them
+    /// Iterate over [`NavMessage`]s, associating them
     /// with the "relevant" entity of the event.
-    pub fn types(&mut self) -> impl Iterator<Item = (&NavEvent, Entity)> + '_ {
-        use NavEvent::{FocusChanged, InitiallyFocused, Locked, NoChanges, Unlocked};
+    pub fn types(&mut self) -> impl Iterator<Item = (&NavMessage, Entity)> + '_ {
+        use NavMessage::{FocusChanged, InitiallyFocused, Locked, NoChanges, Unlocked};
         self.event_reader.read().filter_map(|event| {
             let entity = match event {
                 NoChanges { from, .. } => Some(*from.first()),
@@ -270,10 +269,10 @@ impl NavEventReader<'_, '_, '_> {
     /// Iterate over query items of _activated_ focusables.
     ///
     /// See [`Self::activated`] for meaning of _"activated"_.
-    pub fn activated_in_query<'b, 'c: 'b, Q: ReadOnlyQueryData, F: QueryFilter>(
+    pub fn activated_in_query<'b, 'c: 'b, 's, Q: ReadOnlyQueryData, F: QueryFilter>(
         &'b mut self,
-        query: &'c Query<Q, F>,
-    ) -> impl Iterator<Item = Q::Item<'c>> + 'b {
+        query: &'c Query<'_, 's, Q, F>,
+    ) -> impl Iterator<Item = Q::Item<'c, 's>> + 'b {
         query.iter_many(self.activated())
     }
 
@@ -281,10 +280,10 @@ impl NavEventReader<'_, '_, '_> {
     ///
     /// Unlike [`Self::activated_in_query`] this works with mutable queries.
     /// see [`Self::activated`] for meaning of _"activated"_.
-    pub fn activated_in_query_foreach_mut<Q: QueryData, F: QueryFilter>(
+    pub fn activated_in_query_foreach_mut<'s, Q: QueryData, F: QueryFilter>(
         &mut self,
-        query: &mut Query<Q, F>,
-        mut for_each: impl FnMut(Q::Item<'_>),
+        query: &mut Query<'_, 's, Q, F>,
+        mut for_each: impl for<'q> FnMut(Q::Item<'q, 's>),
     ) {
         let mut iter = query.iter_many_mut(self.activated());
         while let Some(item) = iter.fetch_next() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@
 [module-event_helpers]: events::NavMessageReaderExt
 [module-marking]: mark
 [module-systems]: systems
-[Name]: bevy::core::Name
 [`NavMessage::FocusChanged`]: events::NavMessage::FocusChanged
 [`NavMessage`]: events::NavMessage
 [`NavMessage::InitiallyFocused`]: events::NavMessage::InitiallyFocused

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,7 @@ impl PluginGroup for DefaultNavigationPlugins {
 #[cfg(test)]
 mod test {
     use crate::prelude::*;
-    use bevy::{ecs::event::Event, prelude::*};
+    use bevy::prelude::*;
 
     use super::*;
     // Why things might fail?
@@ -481,12 +481,12 @@ mod test {
                 .unwrap();
             self.app
                 .world_mut()
-                .send_event(NavRequest::FocusOn(requested));
+                .write_message(NavRequest::FocusOn(requested));
             self.app.update();
             receive_events(self.app.world_mut())
         }
         fn run_request(&mut self, request: NavRequest) -> Vec<NavMessage> {
-            self.app.world_mut().send_event(request);
+            self.app.world_mut().write_message(request);
             self.app.update();
             receive_events(self.app.world_mut())
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,10 @@
 /*!
-[`ButtonBundle`]: bevy::prelude::ButtonBundle
 [Changed]: bevy::prelude::Changed
 [doc-root]: ./index.html
 [`Entity`]: bevy::prelude::Entity
 [entity-id]: bevy::ecs::system::EntityCommands::id
-[`FocusableButtonBundle`]: components::FocusableButtonBundle
 [`Focusable::cancel`]: resolve::Focusable::cancel
 [`Focusable::block`]: resolve::Focusable::block
-[`Focusable::dormant`]: resolve::Focusable::dormant
 [`Focusable`]: resolve::Focusable
 [`Focusable::lock`]: resolve::Focusable::lock
 [`generic_default_mouse_input`]: systems::generic_default_mouse_input

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,13 +13,13 @@
 [`generic_default_mouse_input`]: systems::generic_default_mouse_input
 [`InputMapping`]: systems::InputMapping
 [`InputMapping::keyboard_navigation`]: systems::InputMapping::keyboard_navigation
-[module-event_helpers]: events::NavEventReaderExt
+[module-event_helpers]: events::NavMessageReaderExt
 [module-marking]: mark
 [module-systems]: systems
 [Name]: bevy::core::Name
-[`NavEvent::FocusChanged`]: events::NavEvent::FocusChanged
-[`NavEvent`]: events::NavEvent
-[`NavEvent::InitiallyFocused`]: events::NavEvent::InitiallyFocused
+[`NavMessage::FocusChanged`]: events::NavMessage::FocusChanged
+[`NavMessage`]: events::NavMessage
+[`NavMessage::InitiallyFocused`]: events::NavMessage::InitiallyFocused
 [`MenuSetting`]: menu::MenuSetting
 [`NavMenu`]: menu::MenuSetting
 [`MenuBuilder`]: menu::MenuBuilder
@@ -56,7 +56,7 @@ use resolve::UiProjectionQuery;
 
 /// Default imports for `bevy_alt_ui_navigation_lite`.
 pub mod prelude {
-    pub use crate::events::{NavEvent, NavEventReaderExt, NavRequest};
+    pub use crate::events::{NavMessage, NavMessageReaderExt, NavRequest};
     pub use crate::menu::{MenuBuilder, MenuSetting};
     pub use crate::resolve::{
         FocusAction, FocusState, Focusable, Focused, MenuNavigationStrategy, NavLock,
@@ -105,7 +105,7 @@ impl<T: 'static + Sync + Send + Component + Clone> Plugin for NavMarkerPropagati
 }
 
 /// The label of the system in which the [`NavRequest`] events are handled, the
-/// focus state of the [`Focusable`]s is updated and the [`NavEvent`] events
+/// focus state of the [`Focusable`]s is updated and the [`NavMessage`] events
 /// are sent.
 ///
 /// Systems updating visuals of UI elements should run _after_ the `NavRequestSystem`,
@@ -149,7 +149,7 @@ impl<T: 'static + Sync + Send + Component + Clone> Plugin for NavMarkerPropagati
 /// ```
 ///
 /// [`NavRequest`]: prelude::NavRequest
-/// [`NavEvent`]: prelude::NavEvent
+/// [`NavMessage`]: prelude::NavMessage
 /// [`Focusable`]: prelude::Focusable
 #[derive(Clone, Debug, Hash, PartialEq, Eq, SystemSet)]
 pub struct NavRequestSystem;
@@ -200,8 +200,8 @@ where
             .register_type::<resolve::TreeMenu>()
             .register_type::<systems::InputMapping>();
 
-        app.add_event::<events::NavRequest>()
-            .add_event::<events::NavEvent>()
+        app.add_message::<events::NavRequest>()
+            .add_message::<events::NavMessage>()
             .insert_resource(resolve::NavLock::new())
             .add_systems(
                 Update,
@@ -401,7 +401,7 @@ mod test {
     /// There is nothing beside that that would prevent converting this into a function.
     macro_rules! assert_expected_focus_change {
         ($app:expr, $events:expr, $expected_from:expr, $expected_to:expr $(,)?) => {
-            if let [NavEvent::FocusChanged { to, from }] = $events {
+            if let [NavMessage::FocusChanged { to, from }] = $events {
                 let actual_from = $app.name_list(&*from);
                 assert_eq!(&*actual_from, $expected_from);
 
@@ -409,7 +409,7 @@ mod test {
                 assert_eq!(&*actual_to, $expected_to);
             } else {
                 panic!(
-                    "Expected a signle FocusChanged NavEvent, got: {:#?}",
+                    "Expected a single FocusChanged NavMessage, got: {:#?}",
                     $events
                 );
             }
@@ -428,9 +428,9 @@ mod test {
             None
         }
     }
-    fn receive_events<E: Event + Clone>(world: &World) -> Vec<E> {
-        let events = world.resource::<Events<E>>();
-        events.iter_current_update_events().cloned().collect()
+    fn receive_events<E: Message + Clone>(world: &World) -> Vec<E> {
+        let events = world.resource::<Messages<E>>();
+        events.iter_current_update_messages().cloned().collect()
     }
 
     /// Wrapper around `App` to make it easier to test the navigation systems.
@@ -445,7 +445,7 @@ mod test {
                 .query_filtered::<&Name, With<Focused>>();
             query.iter(self.app.world()).next().unwrap()
         }
-        fn kill_named(&mut self, to_kill: &str) -> Vec<NavEvent> {
+        fn kill_named(&mut self, to_kill: &str) -> Vec<NavMessage> {
             let mut query = self.app.world_mut().query::<(Entity, &Name)>();
             let requested = query
                 .iter(self.app.world())
@@ -473,7 +473,7 @@ mod test {
 
             Self { app }
         }
-        fn run_focus_on(&mut self, entity_name: &str) -> Vec<NavEvent> {
+        fn run_focus_on(&mut self, entity_name: &str) -> Vec<NavMessage> {
             let mut query = self.app.world_mut().query::<(Entity, &Name)>();
             let requested = query
                 .iter(self.app.world())
@@ -485,7 +485,7 @@ mod test {
             self.app.update();
             receive_events(self.app.world_mut())
         }
-        fn run_request(&mut self, request: NavRequest) -> Vec<NavEvent> {
+        fn run_request(&mut self, request: NavRequest) -> Vec<NavMessage> {
             self.app.world_mut().send_event(request);
             self.app.update();
             receive_events(self.app.world_mut())

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -5,7 +5,7 @@
 //! This module defines two systems:
 //! 1. [`listen_nav_requests`]: the system gathering [`NavRequest`] and running
 //!    the [`resolve`] algorithm on them, updating the [`Focusable`] states and
-//!    sending [`NavEvent`] as result.
+//!    sending [`NavMessage`] as result.
 //! 2. [`insert_tree_menus`]: system responsible to convert [`MenuBuilder`] defined
 //!    in [`crate::menu`] into [`TreeMenu`], which is the component used by
 //!    the resolution algorithm.
@@ -46,8 +46,10 @@ use bevy::prelude::{Changed, FromWorld};
 use bevy::reflect::Reflect;
 use bevy::{
     ecs::{
-        event::{EventReader, EventWriter},
-        prelude::{Commands, Component, Entity, ParamSet, Query, ResMut, Resource, With, Without},
+        prelude::{
+            Commands, Component, Entity, MessageReader, MessageWriter, ParamSet, Query, ResMut,
+            Resource, With, Without,
+        },
         system::{StaticSystemParam, SystemParam, SystemParamItem},
     },
     math::Vec2,
@@ -62,7 +64,7 @@ use non_empty_vec::NonEmpty;
 
 use crate::{
     commands::set_focus_state,
-    events::{self, NavEvent, NavRequest},
+    events::{self, NavMessage, NavRequest},
     menu::{MenuBuilder, MenuSetting},
 };
 
@@ -441,7 +443,7 @@ pub enum FocusAction {
     /// while this [`Focusable`] is focused,
     /// the navigation system will freeze
     /// until [`NavRequest::Unlock`] is received,
-    /// sending a [`NavEvent::Unlocked`].
+    /// sending a [`NavMessage::Unlocked`].
     ///
     /// This is useful to implement widgets with complex controls
     /// you don't want to accidentally unfocus,
@@ -691,7 +693,7 @@ fn resolve<STGY: MenuNavigationStrategy>(
     lock: &mut ResMut<NavLock>,
     from: Vec<Entity>,
     strategy: &STGY,
-) -> NavEvent {
+) -> NavMessage {
     use FocusState::Blocked;
     use NavRequest::*;
 
@@ -712,22 +714,22 @@ fn resolve<STGY: MenuNavigationStrategy>(
         ($to_match:expr) => {
             match $to_match {
                 Some(x) => x,
-                None => return NavEvent::NoChanges { from, request },
+                None => return NavMessage::NoChanges { from, request },
             }
         };
     }
     match request {
         Lock => {
             if lock.is_locked() {
-                return NavEvent::NoChanges { from, request };
+                return NavMessage::NoChanges { from, request };
             }
             let reason = LockReason::NavRequest;
             lock.lock_reason = Some(reason);
-            NavEvent::Locked(reason)
+            NavMessage::Locked(reason)
         }
         Move(direction) => {
             let (parent, cycles) = match queries.parent_menu(focused) {
-                Some(val) if !val.2.is_2d() => return NavEvent::NoChanges { from, request },
+                Some(val) if !val.2.is_2d() => return NavMessage::NoChanges { from, request },
                 Some(val) => (Some(val.0), !val.2.bound()),
                 None => (None, true),
             };
@@ -737,13 +739,13 @@ fn resolve<STGY: MenuNavigationStrategy>(
                 None => queries.focusables.iter().filter_map(unblocked).collect(),
             };
             let to = strategy.resolve_2d(focused, direction, cycles, &siblings);
-            NavEvent::focus_changed(*or_none!(to), from)
+            NavMessage::focus_changed(*or_none!(to), from)
         }
         Cancel => {
             let to = or_none!(queries.parent_menu(focused));
             let to = or_none!(to.1.focus_parent);
             from.push(to);
-            NavEvent::focus_changed(to, from)
+            NavMessage::focus_changed(to, from)
         }
         Action => {
             match queries.focusables.get(focused).map(|e| e.1.action) {
@@ -755,14 +757,14 @@ fn resolve<STGY: MenuNavigationStrategy>(
                 Ok(FocusAction::Lock) => {
                     let reason = LockReason::Focusable(focused);
                     lock.lock_reason = Some(reason);
-                    return NavEvent::Locked(reason);
+                    return NavMessage::Locked(reason);
                 }
                 Err(_) | Ok(FocusAction::Normal) => {}
             }
             let child_menu = child_menu(focused, queries);
             let (_, menu, _) = or_none!(child_menu);
             let to = (menu.active_child, from.clone().into()).into();
-            NavEvent::FocusChanged { to, from }
+            NavMessage::FocusChanged { to, from }
         }
         // "Tab move" nested movement
         ScopeMove(scope_dir) => {
@@ -779,7 +781,7 @@ fn resolve<STGY: MenuNavigationStrategy>(
                     None => Vec::new(),
                 };
                 let to = (extra, *to).into();
-                NavEvent::FocusChanged { to, from }
+                NavMessage::FocusChanged { to, from }
             }
         }
         FocusOn(new_to_focus) => {
@@ -789,17 +791,17 @@ fn resolve<STGY: MenuNavigationStrategy>(
             let mut to = queries.root_path(new_to_focus);
             trim_common_tail(&mut from, &mut to);
             if from == to {
-                NavEvent::NoChanges { from, request }
+                NavMessage::NoChanges { from, request }
             } else {
-                NavEvent::FocusChanged { from, to }
+                NavMessage::FocusChanged { from, to }
             }
         }
         Unlock => {
             if let Some(lock_entity) = lock.lock_reason.take() {
-                NavEvent::Unlocked(lock_entity)
+                NavMessage::Unlocked(lock_entity)
             } else {
                 warn!("Received a NavRequest::Unlock while not locked");
-                NavEvent::NoChanges { from, request }
+                NavMessage::NoChanges { from, request }
             }
         }
     }
@@ -845,13 +847,13 @@ pub(crate) fn insert_tree_menus(
 pub(crate) fn set_first_focused(
     has_focused: Query<(), With<Focused>>,
     mut queries: ParamSet<(NavQueries, MutQueries)>,
-    mut events: EventWriter<NavEvent>,
+    mut events: MessageWriter<NavMessage>,
 ) {
     if has_focused.is_empty() {
         if let Some(to_focus) = queries.p0().pick_first_focused() {
             let breadcrumb = queries.p0().root_path(to_focus);
             queries.p1().update_focus(&[], &breadcrumb);
-            events.write(NavEvent::InitiallyFocused(to_focus));
+            events.write(NavMessage::InitiallyFocused(to_focus));
         }
     }
 }
@@ -885,8 +887,8 @@ pub(crate) fn listen_nav_requests<STGY: SystemParam>(
     mut queries: ParamSet<(NavQueries, MutQueries)>,
     mquery: StaticSystemParam<STGY>,
     mut lock: ResMut<NavLock>,
-    mut requests: EventReader<NavRequest>,
-    mut events: EventWriter<NavEvent>,
+    mut requests: MessageReader<NavRequest>,
+    mut events: MessageWriter<NavMessage>,
 ) where
     for<'w, 's> SystemParamItem<'w, 's, STGY>: MenuNavigationStrategy,
 {
@@ -914,7 +916,7 @@ pub(crate) fn listen_nav_requests<STGY: SystemParam>(
         };
         let from = Vec::new();
         let event = resolve(focused, *request, &queries.p0(), &mut lock, from, &*mquery);
-        if let NavEvent::FocusChanged { to, from } = &event {
+        if let NavMessage::FocusChanged { to, from } = &event {
             computed_focused = Some(queries.p1().update_focus(from, to));
         };
         events.write(event);

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -68,7 +68,7 @@ use crate::{
 /// System parameter used to resolve movement and cycling focus updates.
 ///
 /// This is useful if you don't want to depend
-/// on bevy's `GlobalTransform` for your UI,
+/// on bevy's `UiGlobalTransform` for your UI,
 /// or want to implement your own navigation algorithm.
 /// For example, if you want your ui to be 3d elements in the world.
 pub trait MenuNavigationStrategy {
@@ -126,7 +126,7 @@ pub(crate) struct ChildQueries<'w, 's> {
 
 /// System parameter for the default cursor navigation system.
 ///
-/// It uses the bevy [`GlobalTransform`] to compute relative positions
+/// It uses the bevy [`UiGlobalTransform`] to compute relative positions
 /// and change focus to the correct entity.
 /// It uses the [`ScreenBoundaries`] resource to compute screen boundaries
 /// and move the cursor accordingly when it reaches a screen border

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -44,6 +44,7 @@ use bevy::log::{debug, warn};
 use bevy::prelude::{Changed, FromWorld};
 #[cfg(feature = "bevy_reflect")]
 use bevy::reflect::Reflect;
+use bevy::ui::UiGlobalTransform;
 use bevy::{
     ecs::{
         prelude::{
@@ -54,11 +55,7 @@ use bevy::{
     },
     math::Vec2,
 };
-use bevy::{
-    math::FloatOrd,
-    math::Vec3Swizzles,
-    prelude::{GlobalTransform, Res},
-};
+use bevy::{math::FloatOrd, prelude::Res};
 
 use non_empty_vec::NonEmpty;
 
@@ -137,7 +134,7 @@ pub(crate) struct ChildQueries<'w, 's> {
 #[derive(SystemParam)]
 pub struct UiProjectionQuery<'w, 's> {
     boundaries: Option<Res<'w, ScreenBoundaries>>,
-    transforms: Query<'w, 's, &'static GlobalTransform>,
+    transforms: Query<'w, 's, &'static UiGlobalTransform>,
 }
 
 /// Collection of queries to manage the navigation tree.
@@ -630,9 +627,8 @@ impl MenuNavigationStrategy for UiProjectionQuery<'_, '_> {
         let pos_of = |entity: Entity| {
             self.transforms
                 .get(entity)
-                .expect("Focusable entities must have a GlobalTransform component")
-                .translation()
-                .xy()
+                .expect("Focusable entities must have a UiTransform component")
+                .translation
         };
         let focused_pos = pos_of(focused);
         let closest = siblings

--- a/src/seeds.rs
+++ b/src/seeds.rs
@@ -163,7 +163,7 @@ pub(crate) struct NavMarker<T>(pub(crate) T);
 ///    hierarchy.
 /// 2. There must not be a menu loop. Ie: a way to go from menu A to menu B and
 ///    then from menu B to menu A while never going back.
-/// 3. Focusables in 2d menus must have a `GlobalTransform`.
+/// 3. Focusables in 2d menus must have a `UiGlobalTransform`.
 ///
 /// # Panics
 ///

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -127,7 +127,7 @@ macro_rules! mapping {
 /// when integrating in the game) in this case, you should write your own
 /// system that sends [`NavRequest`] events
 pub fn default_gamepad_input(
-    mut nav_cmds: EventWriter<NavRequest>,
+    mut nav_cmds: MessageWriter<NavRequest>,
     has_focused: Query<(), With<Focused>>,
     input_mapping: Res<InputMapping>,
     gamepads: Query<(Entity, &Gamepad)>,
@@ -200,7 +200,7 @@ pub fn default_keyboard_input(
     has_focused: Query<(), With<Focused>>,
     keyboard: Res<ButtonInput<KeyCode>>,
     input_mapping: Res<InputMapping>,
-    mut nav_cmds: EventWriter<NavRequest>,
+    mut nav_cmds: MessageWriter<NavRequest>,
 ) {
     use Direction::*;
     use NavRequest::*;
@@ -327,7 +327,7 @@ pub fn default_mouse_input(
     mouse: Res<ButtonInput<MouseButton>>,
     focusables: NodePosQuery<ComputedNode>,
     focused: Query<Entity, With<Focused>>,
-    nav_cmds: EventWriter<NavRequest>,
+    nav_cmds: MessageWriter<NavRequest>,
     last_pos: Local<Vec2>,
 ) {
     generic_default_mouse_input(
@@ -360,7 +360,7 @@ pub fn generic_default_mouse_input<T: ScreenSize + Component>(
     mouse: Res<ButtonInput<MouseButton>>,
     focusables: NodePosQuery<T>,
     focused: Query<Entity, With<Focused>>,
-    mut nav_cmds: EventWriter<NavRequest>,
+    mut nav_cmds: MessageWriter<NavRequest>,
     mut last_pos: Local<Vec2>,
 ) {
     let no_focusable_msg = "Entity with `Focused` component must also have a `Focusable` component";

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -4,7 +4,7 @@ use crate::{
     resolve::{FocusState, Focusable, Focused, ScreenBoundaries},
 };
 
-use bevy::math::FloatOrd;
+use bevy::ui::UiStack;
 use bevy::window::PrimaryWindow;
 #[cfg(feature = "bevy_reflect")]
 use bevy::{ecs::reflect::ReflectResource, reflect::Reflect};
@@ -249,11 +249,12 @@ pub struct NodePosQuery<'w, 's, T: Component> {
         (
             Entity,
             &'static T,
-            &'static GlobalTransform,
+            &'static UiGlobalTransform,
             &'static Focusable,
         ),
     >,
     boundaries: Option<Res<'w, ScreenBoundaries>>,
+    ui_stack: Res<'w, UiStack>,
 }
 impl<T: Component> NodePosQuery<'_, '_, T> {
     fn cursor_pos(&self, at: Vec2) -> Option<Vec2> {
@@ -264,9 +265,9 @@ impl<T: Component> NodePosQuery<'_, '_, T> {
 
 fn is_in_node<T: ScreenSize>(
     at: Vec2,
-    (_, node, trans, _): &(Entity, &T, &GlobalTransform, &Focusable),
+    (_, node, trans, _): &(Entity, &T, &UiGlobalTransform, &Focusable),
 ) -> bool {
-    let ui_pos = trans.translation().truncate();
+    let ui_pos = trans.translation;
     let node_half_size = node.size() / 2.0;
     let min = ui_pos - node_half_size;
     let max = ui_pos + node_half_size;
@@ -281,12 +282,17 @@ where
     T: ScreenSize + Component,
 {
     let world_at = query.cursor_pos(at)?;
+
     query
-        .entities
+        .ui_stack
+        .uinodes
         .iter()
+        // reverse the iterator to traverse the tree from closest nodes to furthest
+        .rev()
+        .filter_map(|entity| query.entities.get(*entity).ok())
         .filter(|query_elem| is_in_node(world_at, query_elem))
-        .max_by_key(|elem| FloatOrd(elem.2.translation().z))
         .map(|elem| elem.0)
+        .next()
 }
 
 fn cursor_pos(window: &Window) -> Option<Vec2> {
@@ -403,12 +409,17 @@ pub fn generic_default_mouse_input<T: ScreenSize + Component>(
         // We only run this code when we really need it because we iterate over all
         // focusables, which can eat a lot of CPU.
         let under_mouse = focusables
-            .entities
+            .ui_stack
+            .uinodes
             .iter()
+            // reverse the iterator to traverse the tree from closest nodes to furthest
+            .rev()
+            .filter_map(|entity| focusables.entities.get(*entity).ok())
             .filter(|query_elem| query_elem.3.state() != FocusState::Blocked)
             .filter(|query_elem| is_in_node(world_cursor_pos, query_elem))
-            .max_by_key(|elem| FloatOrd(elem.2.translation().z))
-            .map(|elem| elem.0);
+            .map(|elem| elem.0)
+            .next();
+
         let to_target = match under_mouse {
             Some(c) => c,
             None => return,


### PR DESCRIPTION
There probably won't be a crates.io release until Bevy 0.17.0 is properly released, but you can use this git branch in the mean time.

```toml
[dependencies.bevy-alt-ui-navigation-lite]
git = "https://github.com/rparrett/bevy-alt-ui-navigation-lite.git"
branch = "bevy-0.17"
```

Maintenance of this project is becoming burdensome for me and I am considering archiving it.

Many simpler use-cases can now be handled by Bevy's [directional navigation](https://bevy.org/examples/ui-user-interface/directional-navigation/). Consider using it instead, if possible.

It's possible that I've broken something related to implementing navigation with non-UI elements due to Bevy's new `UiGlobalTransform`. If that's the case, I would appreciate help unbreaking it.